### PR TITLE
Compatible with python3

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -40,11 +40,11 @@ def decode(ori_path, img_path, res_path, alpha):
     watermark = np.real(watermark)
     res = np.zeros(watermark.shape)
     random.seed(height + width)
-    x = range(height / 2)
+    x = range(int(height / 2))
     y = range(width)
-    random.shuffle(x)
-    random.shuffle(y)
-    for i in range(height / 2):
+    random.shuffle(list(x))
+    random.shuffle(list(y))
+    for i in range(int(height / 2)):
         for j in range(width):
             res[x[i]][y[j]] = watermark[i][j]
     cv2.imwrite(res_path, res, [int(cv2.IMWRITE_JPEG_QUALITY), 100])

--- a/encode.py
+++ b/encode.py
@@ -24,7 +24,7 @@ def main():
     res = options.res
     alpha = float(options.alpha)
     if not os.path.isfile(img):
-        parser.error("image %s does not eist." % img)
+        parser.error("image %s does not exist." % img)
     if not os.path.isfile(wm):
         parser.error("watermark %s does not exist." % wm)
     encode(img, wm, res, alpha)

--- a/encode.py
+++ b/encode.py
@@ -24,7 +24,7 @@ def main():
     res = options.res
     alpha = float(options.alpha)
     if not os.path.isfile(img):
-        parser.error("image %s does not exist." % img)
+        parser.error("image %s does not eist." % img)
     if not os.path.isfile(wm):
         parser.error("watermark %s does not exist." % wm)
     encode(img, wm, res, alpha)
@@ -36,12 +36,12 @@ def encode(img_path, wm_path, res_path, alpha):
     height, width, channel = np.shape(img)
     watermark = cv2.imread(wm_path)
     wm_height, wm_width = watermark.shape[0], watermark.shape[1]
-    x, y = range(height / 2), range(width)
+    x, y = range(int(height / 2)), range(width)
     random.seed(height + width)
-    random.shuffle(x)
-    random.shuffle(y)
+    random.shuffle(list(x))
+    random.shuffle(list(y))
     tmp = np.zeros(img.shape)
-    for i in range(height / 2):
+    for i in range(int(height / 2)):
         for j in range(width):
             if x[i] < wm_height and y[j] < wm_width:
                 tmp[i][j] = watermark[x[i]][y[j]]


### PR DESCRIPTION
Fix some type errors when running with python3.

In python2, range can return a list:

```python
>>> range(5)
[0, 1, 2, 3, 4]
```
In python3 range just return a range:

```python
>>> range(5)
range(5)
>>> a = range(5)
>>> a
range(0, 5)
```

if you want get a list should do as:

```python
>>> list(range(5))
[0, 1, 2, 3, 4]
```

In python2, If the result of your division is an integer it will return an integer, but in python3 it will return a float:

python2:
```python
>>> type(5/1)
<type 'int'>
```

python3:
```python
>>> type(5/1)
<class 'float'>
```
