### PR TITLE
Fix shuffle bug in Python 3

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -40,10 +40,10 @@ def decode(ori_path, img_path, res_path, alpha):
     watermark = np.real(watermark)
     res = np.zeros(watermark.shape)
     random.seed(height + width)
-    x = range(int(height / 2))
-    y = range(width)
-    random.shuffle(list(x))
-    random.shuffle(list(y))
+    x = list(range(int(height / 2)))
+    y = list(range(width))
+    random.shuffle(x)
+    random.shuffle(y)
     for i in range(int(height / 2)):
         for j in range(width):
             res[x[i]][y[j]] = watermark[i][j]

--- a/encode.py
+++ b/encode.py
@@ -36,10 +36,10 @@ def encode(img_path, wm_path, res_path, alpha):
     height, width, channel = np.shape(img)
     watermark = cv2.imread(wm_path)
     wm_height, wm_width = watermark.shape[0], watermark.shape[1]
-    x, y = range(int(height / 2)), range(width)
+    x, y = list(range(int(height / 2))), list(range(width))
     random.seed(height + width)
-    random.shuffle(list(x))
-    random.shuffle(list(y))
+    random.shuffle(x)
+    random.shuffle(y)
     tmp = np.zeros(img.shape)
     for i in range(int(height / 2)):
         for j in range(width):
@@ -50,5 +50,7 @@ def encode(img_path, wm_path, res_path, alpha):
     res = np.fft.ifft2(res_f)
     res = np.real(res)
     cv2.imwrite(res_path, res, [int(cv2.IMWRITE_JPEG_QUALITY), 100])
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If casting in `shuffle`, original variables won't be affected.